### PR TITLE
mysql invalid default value for 'expiry_date'

### DIFF
--- a/includes/core.update.php
+++ b/includes/core.update.php
@@ -13,6 +13,10 @@
 
 $allowed_update = array(9,8,7);
 if (current_role_in($allowed_update)) {
+	
+    $statement = $dbh->prepare("SET SQL_MODE='ALLOW_INVALID_DATES';");
+    $statement->execute();
+	
     $update_data = get_latest_version_data();
     $update_data = json_decode($update_data);
 
@@ -1362,4 +1366,7 @@ if (current_role_in($allowed_update)) {
         ]);
         
     }
+	
+    $statement = $dbh->prepare("SET SQL_MODE='';");
+    $statement->execute();
 }


### PR DESCRIPTION
For a migration from r754 to r1295 (MySQL version 5.7.35) I have the error.

The following modification corrects my problem.

I don't know if this will be helpful for you